### PR TITLE
Fix memory leak in fetch_url()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ libs		+= libcurl libconfig
 
 CFLAGS		+= -fPIC -pthread -D_GNU_SOURCE $(shell pkg-config --cflags ${libs})
 
-LDFLAGS		:= -shared -lpam -pthread $(shell pkg-config --libs ${libs})
+LDFLAGS		+= -shared -lpam -pthread $(shell pkg-config --libs ${libs})
 
 arch		:= $(shell uname -m)
 pamlib		:= lib/security


### PR DESCRIPTION
fetch_url() needs to call curl_global_cleanup() paired with curl_global_init() to prevent memory leaks and high CPU usage if pam_url is used in a long running process.