### PR TITLE
Don't force the use of a client SSL certificate

### DIFF
--- a/pam_url.c
+++ b/pam_url.c
@@ -123,10 +123,11 @@ int parse_opts(pam_url_opts *opts, int argc, const char *argv[], int mode)
 	
 	// SSL Options
 	if(config_lookup_string(&config, "pam_url.ssl.client_cert", &opts->ssl_cert) == CONFIG_FALSE)
-		opts->ssl_cert = DEF_SSLCERT;
+		opts->ssl_cert = NULL;
 	
 	if(config_lookup_string(&config, "pam_url.ssl.client_key", &opts->ssl_key) == CONFIG_FALSE)
-		opts->ssl_key = DEF_SSLKEY;
+		opts->ssl_key = NULL;
+	
 	if(config_lookup_string(&config, "pam_url.ssl.ca_cert", &opts->ca_cert) == CONFIG_FALSE)
 		opts->ca_cert = DEF_CA_CERT;
 	

--- a/pam_url.h
+++ b/pam_url.h
@@ -71,14 +71,6 @@
 	#define DEF_CA_CERT "/etc/pki/tls/certs/ca-bundle.crt"
 #endif
 
-#ifndef DEF_SSLKEY
-	#define DEF_SSLKEY "/etc/pki/pam_url_key.pem"
-#endif
-
-#ifndef DEF_SSLCERT
-    #define DEF_SSLCERT "/etc/pki/pam_url_cert.pem"
-#endif
-
 #ifndef DEF_PROMPT
     #define DEF_PROMPT "Password: "
 #endif


### PR DESCRIPTION
Previously, when the SSL client certificate file did not exist, libcurl would just not use a client certificate. Now, apparently due to the change from NSS to OpenSSL, this results in a fatal error.

The best fix is simply not to assume a default for the client certificate (and private key) file name.