### PR TITLE
Fix compatibility with gcc 10

### DIFF
--- a/pam_url.c
+++ b/pam_url.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
+bool pam_url_debug;
 char* recvbuf = NULL;
 size_t recvbuf_size = 0;
 static config_t config;

--- a/pam_url.h
+++ b/pam_url.h
@@ -83,7 +83,7 @@
     #define DEF_PROMPT "Password: "
 #endif
 
-bool pam_url_debug;
+extern bool pam_url_debug;
 
 typedef struct pam_url_opts_ {
 	const char *url;


### PR DESCRIPTION
See https://gcc.gnu.org/gcc-10/porting_to.html

> A common mistake in C is omitting `extern` when declaring a global variable in a header file. If the header is included by several files it results in multiple definitions of the same variable. In previous GCC versions this error is ignored. GCC 10 defaults to `-fno-common`, which means a linker error will now be reported. To fix this, use `extern` in header files when declaring global variables, and ensure each global is defined in exactly one C file.

In this case, the variable `pam_url_debug` is only used in `pam_url.c` and could just have been declared there rather than in `pam_url.h`, but fixing the declaration in `pam_url.h` and moving the definition to `pam_url.c` maintains the variable as a global so it could be accessed from other .c files in future if desired.

This fixes #9.